### PR TITLE
[MCC-138874] Feature/arbitrary initializers

### DIFF
--- a/lib/crichton_test_service.rb
+++ b/lib/crichton_test_service.rb
@@ -9,10 +9,11 @@ module CrichtonTestService
   end
 
   # Uses Process.spawn to setup and spin up the crichton demo service rails server
-  def self.spawn_rails_process!(port = 3000)
+  def self.spawn_rails_process!(port = 3000, initializer_directory = nil)
     rails_root = File.dirname(__FILE__) << '/crichton_test_service'
-    Dir.chdir(rails_root) { system(env_vars_hash(port), 'bundle exec rake setup') }
-    @pid = Process.spawn("bundle exec rails server --port #{port}", chdir: "#{rails_root}")
+    env_vars = env_vars_hash(port, initializer_directory)
+    Dir.chdir(rails_root) { system(env_vars, 'bundle exec rake setup') }
+    @pid = Process.spawn(env_vars, "bundle exec rails server --port #{port}", chdir: "#{rails_root}")
     wait_for_response!("http://localhost:#{port}")
   ensure
     return @pid
@@ -33,13 +34,14 @@ module CrichtonTestService
     end
   end
 
-  def self.env_vars_hash(port)
+  def self.env_vars_hash(port, initializer_directory)
     localhost = "http://localhost:#{port}"
     {
       "ALPS_BASE_URI" => "#{localhost}/alps",
       "DEPLOYMENT_BASE_URI" => localhost,
       "DISCOVERY_BASE_URI" => localhost,
-      "CRICHTON_PROXY_BASE_URI" => "#{localhost}/crichton"
+      "CRICHTON_PROXY_BASE_URI" => "#{localhost}/crichton",
+      "INITIALIZER_DIRECTORY" => initializer_directory
     }
   end
 end

--- a/lib/crichton_test_service/config/initializers/external_initializers.rb
+++ b/lib/crichton_test_service/config/initializers/external_initializers.rb
@@ -1,0 +1,1 @@
+Dir["#{ENV['INITIALIZER_DIRECTORY']}/*.rb"].each {|file| require file } if ENV["INITIALIZER_DIRECTORY"]

--- a/spec/fixtures/custom_initializer.rb
+++ b/spec/fixtures/custom_initializer.rb
@@ -1,0 +1,17 @@
+require 'rack'
+
+module Rack
+  class FakeResponder
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      [200, {"ContentType" => "text/html"}, ["Alive!"]]
+    end
+  end
+end
+
+config = CrichtonDemoService::Application.config
+# Crichton will hijack calls to root if you don't insert yourself above it
+config.middleware.insert_after Rack::Lock, Rack::FakeResponder

--- a/spec/integration/test_service_spec.rb
+++ b/spec/integration/test_service_spec.rb
@@ -5,6 +5,8 @@ require 'crichton_test_service'
 RSpec.describe CrichtonTestService do
   # NB: Do not use any additional nested context blocks unless you want to spin up a
   # rails process for each one.
+  let(:conn) { Faraday.new(ROOT_URL) }
+
   context "When the service is running" do
     before(:all) do
       old_handler = trap(:INT) {
@@ -14,8 +16,6 @@ RSpec.describe CrichtonTestService do
       @rails_pid = CrichtonTestService.spawn_rails_process!(port = 1234)
     end
     after(:all) { Process.kill(:INT, @rails_pid) if @rails_pid }
-
-    let(:conn) { Faraday.new(ROOT_URL) }
 
     # Start up the service, and ensure INT also kills the service
     it 'responds to root' do
@@ -55,4 +55,11 @@ RSpec.describe CrichtonTestService do
     end
   end
 
+  context 'when provided an initializer directory' do
+    it 'executes the initialization code' do
+      pid = CrichtonTestService.spawn_rails_process!(1234, "#{SPEC_DIR}/fixtures" )
+      expect(conn.get('/').body).to eq("Alive!")
+      Process.kill(:INT, pid)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'pry'
 
 ROOT_URL = "http://localhost:1234"
+SPEC_DIR = File.expand_path("..", __FILE__)
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
So this lets us include arbitrary initializers into the crichton test service so we can do things like include mauth middleware for our nefarious testing purposes.

@yzhangmedidata @HonoreDB

```
Finished in 15.47 seconds (files took 0.28849 seconds to load)
12 examples, 0 failures, 6 pending

Randomized with seed 26907
```
