### PR TITLE
[MCC-138094] Feature/more tests

### DIFF
--- a/spec/integration/test_service_spec.rb
+++ b/spec/integration/test_service_spec.rb
@@ -1,6 +1,7 @@
 require 'faraday'
 require 'json'
 require 'crichton_test_service'
+require 'representors'
 
 RSpec.describe CrichtonTestService do
   # NB: Do not use any additional nested context blocks unless you want to spin up a
@@ -8,50 +9,59 @@ RSpec.describe CrichtonTestService do
   let(:conn) { Faraday.new(ROOT_URL) }
 
   context "When the service is running" do
-    before(:all) do
-      old_handler = trap(:INT) {
-        Process.kill(:INT, @rails_pid) if @rails_pid
-        old_handler.call if old_handler.respond_to?(:call)
-      }
-      @rails_pid = CrichtonTestService.spawn_rails_process!(port = 1234)
-    end
-    after(:all) { Process.kill(:INT, @rails_pid) if @rails_pid }
+    context "When requesting hale json" do
+      before(:all) do
+        old_handler = trap(:INT) {
+          Process.kill(:INT, @rails_pid) if @rails_pid
+          old_handler.call if old_handler.respond_to?(:call)
+        }
+        @rails_pid = CrichtonTestService.spawn_rails_process!(port = 1234)
+      end
+      after(:all) { Process.kill(:INT, @rails_pid) if @rails_pid }
 
-    # Start up the service, and ensure INT also kills the service
-    it 'responds to root' do
-      expect(conn.get('/').status).to eq(200)
-    end
+      let(:conn) { Faraday.new(ROOT_URL) }
+      let(:drds) do
+        response_body = conn.get('/drds.hale_json', conditions: ["can_do_anything"]).body
+        Representors::HaleDeserializer.new(response_body).to_representor
+      end
 
-    it 'responds to an index call' do
-      expect(conn.get('/drds.hale_json').status).to eq(200)
-    end
+      it 'responds to root' do
+        expect(conn.get('/').status).to eq(200)
+      end
 
-    it 'includes transitions when conditions are met' do
-      response = conn.get('/drds.hale_json', { conditions: ["can_create"] })
-      expect(JSON.parse(response.body)["_links"]).to have_key("create")
-    end
+      it 'responds to an index call' do
+        expect(conn.get('/drds.hale_json').status).to eq(200)
+      end
 
-    it 'filters out available transitions for unmet conditions' do
-      response = conn.get('/drds.hale_json', { conditions: [] })
-      expect(JSON.parse(response.body)["_links"]).to_not have_key("create")
-    end
+      it 'includes transitions when conditions are met' do
+        response = conn.get('/drds.hale_json', { conditions: ["can_create"] })
+        expect(JSON.parse(response.body)["_links"]).to have_key("create")
+      end
 
-    xit 'responds to a show call' do
-    end
+      it 'filters out available transitions for unmet conditions' do
+        response = conn.get('/drds.hale_json', { conditions: [] })
+        expect(JSON.parse(response.body)["_links"]).to_not have_key("create")
+      end
 
-    xit 'responds to a create call' do
-    end
+      it 'responds to a show call' do
+        show_url = drds.transitions.find { |tran| tran.rel == "items" }.uri
+        expect(conn.get("#{show_url}.hale_json").status).to eq(200)
+      end
 
-    xit 'responds to an update call' do
-    end
+      xit 'responds to a create call' do
+      end
 
-    xit 'responds to a destroy call' do
-    end
+      xit 'responds to an update call' do
+      end
 
-    xit 'responds to an activate call' do
-    end
+      xit 'responds to a destroy call' do
+      end
 
-    xit 'responds to a deactivate call' do
+      xit 'responds to an activate call' do
+      end
+
+      xit 'responds to a deactivate call' do
+      end
     end
   end
 

--- a/spec/integration/test_service_spec.rb
+++ b/spec/integration/test_service_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe CrichtonTestService do
         Representors::HaleDeserializer.new(response_body).to_representor
       end
 
-      it 'responds to root' do
+      it 'responds appropriately to root' do
         expect(conn.get('/').status).to eq(200)
       end
 
-      it 'responds to an index call' do
+      it 'responds appropriately to a drd index call' do
         expect(conn.get('/drds.hale_json').status).to eq(200)
       end
 
@@ -43,12 +43,18 @@ RSpec.describe CrichtonTestService do
         expect(JSON.parse(response.body)["_links"]).to_not have_key("create")
       end
 
-      it 'responds to a show call' do
+      it 'responds appropriately to a drd show call' do
         show_url = drds.transitions.find { |tran| tran.rel == "items" }.uri
         expect(conn.get("#{show_url}.hale_json").status).to eq(200)
       end
 
-      xit 'responds to a create call' do
+      it 'responds appropriately to a drd create call specifying name' do
+        create_url = drds.transitions.find { |tran| tran.rel == "create" }.uri
+        response = conn.post("#{create_url}.hale_json", {name: 'Pike'})
+        expect(response.status).to eq(201)
+        drd = Representors::HaleDeserializer.new(response.body).to_representor
+        self_url = drd.transitions.find { |tran| tran.rel == "self" }.uri
+        expect(conn.get(self_url).status).to eq(200)
       end
 
       xit 'responds to an update call' do

--- a/spec/integration/test_service_spec.rb
+++ b/spec/integration/test_service_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe CrichtonTestService do
         response_body = conn.get('/drds.hale_json', conditions: ["can_do_anything"]).body
         Representors::HaleDeserializer.new(response_body).to_representor
       end
+      let(:create_url) { "#{drds.transitions.find { |tran| tran.rel == "create" }.uri}.hale_json" }
 
       it 'responds appropriately to root' do
         expect(conn.get('/').status).to eq(200)
@@ -49,12 +50,17 @@ RSpec.describe CrichtonTestService do
       end
 
       it 'responds appropriately to a drd create call specifying name' do
-        create_url = drds.transitions.find { |tran| tran.rel == "create" }.uri
-        response = conn.post("#{create_url}.hale_json", {name: 'Pike'})
+        response = conn.post(create_url, {name: 'Pike'})
         expect(response.status).to eq(201)
         drd = Representors::HaleDeserializer.new(response.body).to_representor
         self_url = drd.transitions.find { |tran| tran.rel == "self" }.uri
         expect(conn.get(self_url).status).to eq(200)
+      end
+
+      # TODO: fix this, it is responding 201
+      xit 'responds with an error to a drd create call not specifying a name' do
+        response = conn.post create_url, {}
+        expect(response.status).to eq(422)
       end
 
       xit 'responds to an update call' do


### PR DESCRIPTION
So I was adding some tests in perpetration for renaming Error to HyperError, and it doesn't look like its behaving as expected, so I'll need to fix the fact it's not actually raising errors first.  Just wanted to check these in before that refactor.  It adds a happy case  spec for drd creates, and a show spec.  Also, I started using Representors instead of manipulating the hale directly.  The diff is a little wonky due to a new context block.

```
Finished in 17.98 seconds (files took 1.04 seconds to load)
13 examples, 0 failures, 5 pending
```
