### PR TITLE
[MCC-140729] Feature/update

### DIFF
--- a/lib/moya/api_descriptors/drds_descriptor.yml
+++ b/lib/moya/api_descriptors/drds_descriptor.yml
@@ -71,7 +71,7 @@ semantics:
     doc: The UUID of the creator Leviathan.
     href: http://alps.io/schema.org/Text
     sample: 1234-5678-9abc-def1
-  destroyed:
+  destroyed_status:
     doc: This DRD has been destroyed
     href: http://alps.io/schema.org/Boolean
     sample: destroyed
@@ -177,7 +177,7 @@ idempotent:
             source: http://crichton.example.com/drd_location_detail_list#items
             target: location_detail_id
             prompt: location_detail_text
-      - href: destroyed
+      - href: destroyed_status
         field_type: boolean
 
 unsafe:
@@ -268,7 +268,7 @@ resources:
       - href: leviathan
       - href: location
       - href: location_detail
-      - href: destroyed
+      - href: destroyed_status
       - href: show
       - href: activate
       - href: deactivate

--- a/lib/moya/app/controllers/drds_controller.rb
+++ b/lib/moya/app/controllers/drds_controller.rb
@@ -2,6 +2,7 @@ require 'drds_decorator'
 
 class DrdsController < ApplicationController
   respond_to :hale_json
+  before_filter :get_drd, except: [:index, :create]
 
   OPTIONS_KEYS = [ :conditions,
     :except,
@@ -29,8 +30,6 @@ class DrdsController < ApplicationController
   end
 
   def show
-    @drd = get_drd
-
     respond_with(@drd, options)
   end
 
@@ -41,28 +40,24 @@ class DrdsController < ApplicationController
   end
 
   def update
-    @drd = get_drd
     @drd.update!(drd_update_params)
 
     redirect_to url_for(@drd), status: :see_other
   end
 
   def activate
-    @drd = get_drd
     @drd.activate!
 
     respond_with(@drd, options)
   end
 
   def deactivate
-    @drd = get_drd
     @drd.deactivate!
 
     respond_with(@drd, options)
   end
 
   def destroy
-    @drd = get_drd
     @drd.destroy!
 
     # Rails render no content still returns a 1 space body, this ensures no body
@@ -90,7 +85,7 @@ class DrdsController < ApplicationController
 
   def get_drd
     # TODO: Fix this.  Gross.
-    Drd.find(UUIDTools::UUID.parse(params[:id]))
+    @drd = Drd.find(UUIDTools::UUID.parse(params[:id]))
   end
 
 end

--- a/lib/moya/app/controllers/drds_controller.rb
+++ b/lib/moya/app/controllers/drds_controller.rb
@@ -40,6 +40,13 @@ class DrdsController < ApplicationController
     respond_with(@drd, options)
   end
 
+  def update
+    @drd = get_drd
+    @drd.update!(drd_update_params)
+
+    respond_with(@drd, options)
+  end
+
   def activate
     @drd = get_drd
     @drd.activate!
@@ -75,6 +82,10 @@ class DrdsController < ApplicationController
 
   def drd_params
     params.require(:drd).permit(:name, :status, :kind, :leviathan_uuid, :leviathan_url)
+  end
+
+  def drd_update_params
+    params.require(:drd).permit(:status, :old_status, :kind, :size, :location, :location_detail, :destroyed_status)
   end
 
   def get_drd

--- a/lib/moya/app/controllers/drds_controller.rb
+++ b/lib/moya/app/controllers/drds_controller.rb
@@ -42,6 +42,7 @@ class DrdsController < ApplicationController
   def update
     @drd.update!(drd_update_params)
 
+    # TODO: Write and respond with a redirect object
     redirect_to url_for(@drd), status: :see_other
   end
 

--- a/lib/moya/app/controllers/drds_controller.rb
+++ b/lib/moya/app/controllers/drds_controller.rb
@@ -44,7 +44,7 @@ class DrdsController < ApplicationController
     @drd = get_drd
     @drd.update!(drd_update_params)
 
-    respond_with(@drd, options)
+    redirect_to url_for(@drd), status: :see_other
   end
 
   def activate

--- a/lib/moya/db/migrate/20141217230849_add_all_drd_attributes.rb
+++ b/lib/moya/db/migrate/20141217230849_add_all_drd_attributes.rb
@@ -1,0 +1,10 @@
+class AddAllDrdAttributes < ActiveRecord::Migration
+  def change
+    add_column :drds, :old_status, :string
+    add_column :drds, :size, :string
+    add_column :drds, :location, :string
+    add_column :drds, :location_detail, :string
+    add_column :drds, :destroyed_status, :boolean, default: 0
+    add_column :drds, :repair_history_url, :string
+  end
+end

--- a/lib/moya/db/schema.rb
+++ b/lib/moya/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141208231338) do
+ActiveRecord::Schema.define(version: 20141217230849) do
 
   create_table "drds", force: true do |t|
     t.string   "name"
@@ -21,6 +21,12 @@ ActiveRecord::Schema.define(version: 20141208231338) do
     t.string   "leviathan_url"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "old_status"
+    t.string   "size"
+    t.string   "location"
+    t.string   "location_detail"
+    t.boolean  "destroyed_status",   default: false
+    t.string   "repair_history_url"
   end
 
   add_index "drds", ["id"], name: "sqlite_autoindex_drds_1", unique: true

--- a/spec/integration/test_service_spec.rb
+++ b/spec/integration/test_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Moya do
       let(:drd_hash) {
           { drd: { name: 'Pike',
             status: 'activated',
-            kind: 'standard',
+            kind: 'Roll-e',
             leviathan_uuid: 'd34c78bd-583c-4eff-a66c-cd9b047417b4',
             leviathan_url: 'http://example.org/leviathan/d34c78bd-583c-4eff-a66c-cd9b047417b4'
           }

--- a/spec/integration/test_service_spec.rb
+++ b/spec/integration/test_service_spec.rb
@@ -1,4 +1,5 @@
 require 'moya'
+require 'active_support'
 
 RSpec.describe Moya do
   # NB: Do not use any additional nested context blocks unless you want to spin up a
@@ -19,7 +20,7 @@ RSpec.describe Moya do
       let(:drd_hash) {
           { drd: { name: 'Pike',
             status: 'activated',
-            kind: 'Roll-e',
+            kind: 'standard',
             leviathan_uuid: 'd34c78bd-583c-4eff-a66c-cd9b047417b4',
             leviathan_url: 'http://example.org/leviathan/d34c78bd-583c-4eff-a66c-cd9b047417b4'
           }
@@ -77,7 +78,28 @@ RSpec.describe Moya do
         expect(response.status).to eq(422)
       end
 
-      xit 'responds to an update call' do
+      it 'responds appropirately to an update call with all permissible attributes' do
+        # Create a drd
+        response = post create_url, drd_hash.merge(can_do_hash)
+        drd = parse_hale(response.body)
+
+        # Update the drd with all permissible attributes
+        expect(drd.properties['name']).to eq('Pike')
+        properties = { 'status' => 'deactivated',
+                       'old_status' => 'activated',
+                       'kind' => 'sentinel',
+                       'size' => 'medium',
+                       'location' => 'Mars',
+                       'location_detail' => 'Olympus Mons',
+                       'destroyed_status' => true
+                     }
+        response = put hale_url_for("update", drd), { drd: properties }
+
+        # Check that it is really updated
+        response = get hale_url_for("self", drd)
+        drd = parse_hale(response.body)
+
+        expect(drd.properties.slice(*properties.keys)).to eq(properties)
       end
 
       it 'responds to a destroy call' do

--- a/spec/integration/test_service_spec.rb
+++ b/spec/integration/test_service_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe Moya do
                        'destroyed_status' => true
                      }
         response = put hale_url_for("update", drd), { drd: properties }
+        expect(response.status).to eq(303)
 
         # Check that it is really updated
         response = get hale_url_for("self", drd)

--- a/spec/moya_test_helper.rb
+++ b/spec/moya_test_helper.rb
@@ -1,3 +1,6 @@
+require 'representors'
+require 'faraday'
+
 # Helper methods
 module MoyaTestHelper
   def conn


### PR DESCRIPTION
Merge after #14

Adds more drd attributes from the descriptor doc, an udpate method, and a happy case update spec.  Also refactors some specs to use a new hale_url_for helper to make things pretty.  I decided to make the udpate 303 to the self link, I think it will be useful for testing following redirects in farscape.

NB: I change destroyed to destroyed_status, as rails has pretty firmly claimed `destroyed`on a model.

```
Finished in 36.96 seconds (files took 0.44797 seconds to load)
14 examples, 0 failures, 1 pending

Randomized with seed 33367
```
