### PR TITLE
[MCC-142269] Crichton require, active uuid chicanery

### DIFF
--- a/lib/moya/Gemfile
+++ b/lib/moya/Gemfile
@@ -27,7 +27,7 @@ gem 'turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 1.2'
 
-gem 'crichton', git: 'git@github.com:mdsol/crichton.git', branch: '0-1-stable' #FIXME
+gem 'crichton', git: 'git@github.com:mdsol/crichton.git', branch: '0-1-stable', require: false #FIXME
 gem 'representors', git: 'git@github.com:mdsol/representors.git', branch: '0-0-stable' #FIXME
 gem 'dice_bag', '~> 0.8'
 gem 'activeuuid', '~> 0.5'

--- a/lib/moya/app/models/drd.rb
+++ b/lib/moya/app/models/drd.rb
@@ -1,3 +1,5 @@
+require 'activeuuid'
+
 class Drd < ActiveRecord::Base
   include ActiveUUID::UUID
   include Crichton::Representor::State

--- a/lib/moya/app/models/drd.rb
+++ b/lib/moya/app/models/drd.rb
@@ -10,7 +10,7 @@ class Drd < ActiveRecord::Base
     self.old_status ||= 'deactivated'
   end
 
-  scope :status, -> (status) { where status: status }
+  scope :status, ->(status) { where status: status }
 
   validates :name, :status, presence: true
   validates :name, length: { maximum: 50 }

--- a/lib/moya/config/application.rb
+++ b/lib/moya/config/application.rb
@@ -9,6 +9,12 @@ Bundler.require(*Rails.groups)
 
 module Moya
   class Application < Rails::Application
+
+
+    config.after_initialize do
+      require 'crichton' unless Object.const_defined?(:Crichton)
+    end
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/lib/moya/db/migrate/20141208231338_add_drds_with_binary_uuids.rb
+++ b/lib/moya/db/migrate/20141208231338_add_drds_with_binary_uuids.rb
@@ -1,4 +1,4 @@
-#TODO Either conctribute to activeuuid, or remove it
+#TODO Either contribute to activeuuid, or remove it
 require 'activeuuid'
 
 class AddDrdsWithBinaryUuids < ActiveRecord::Migration

--- a/lib/moya/db/migrate/20141208231338_add_drds_with_binary_uuids.rb
+++ b/lib/moya/db/migrate/20141208231338_add_drds_with_binary_uuids.rb
@@ -1,3 +1,6 @@
+#TODO Either conctribute to activeuuid, or remove it
+require 'activeuuid'
+
 class AddDrdsWithBinaryUuids < ActiveRecord::Migration
   def change
     create_table :drds, id: false do |t|

--- a/moya.gemspec
+++ b/moya.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'faraday'
   spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'activeuuid'
 
   # TODO: add dependencies on Crichton and Representors when hosted off git.
   # TODO: make it clear in README.md that this gem should only be listed as a development dependency
@@ -34,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rack'
   spec.add_dependency 'nokogiri'
   spec.add_dependency 'yajl-ruby', '~> 1.2.0'
+  spec.add_dependency 'activeuuid'
 end

--- a/spec/moya_test_helper.rb
+++ b/spec/moya_test_helper.rb
@@ -12,8 +12,12 @@ module MoyaTestHelper
     parse_hale(conn.get('/drds.hale_json', conditions: ["can_do_anything"]).body)
   end
 
-  def get(url, params = {})
-    conn.get(url, params)
+  def get(url, params = {}, headers = {})
+    conn.get(url, params) do |req|
+      headers.each do |k,v|
+        req.headers[k] = v
+      end
+    end
   end
 
   def put(url, hash_body = {})


### PR DESCRIPTION
So this addresses a couple of issues.
1) Migrations were failing due to an error being raised when uuid was called, this is addressed with a require and a cranky comment.
2) For Crichton testing, @HonoreDB's idea of adding a `require: false` and then adding an after initialize hook to require Crichton seems to work great.
3) Move activeuuid from a development dependency to a dependency

```
Finished in 1 minute 2.83 seconds (files took 1.5 seconds to load)
23 examples, 0 failures
[2015-01-05 18:23:05] INFO  WEBrick::HTTPServer#start done.

Randomized with seed 30034
```
