### PR TITLE
Feature/travis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in crichton_test_service.gemspec
 gemspec
 
-gem 'crichton', git: 'git@github.com:mdsol/crichton.git', branch: '0-1-stable'
-gem 'representors', git: 'git@github.com:mdsol/representors.git', branch: '0-0-stable'
+gem 'crichton', git: 'git@github.com:mdsol-share/crichton.git', branch: '0-1-stable'
+gem 'representors', git: 'git@github.com:mdsol-share/representors.git', branch: '0-0-stable'

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in crichton_test_service.gemspec
 gemspec
 
-gem 'crichton', git: 'git@github.com:mdsol-share/crichton.git', branch: '0-1-stable'
-gem 'representors', git: 'git@github.com:mdsol-share/representors.git', branch: '0-0-stable'
+gem 'crichton', git: 'git@github.com:mdsol-share/crichton.git', branch: 'develop'
+gem 'representors', git: 'git@github.com:mdsol-share/representors.git', branch: 'develop'

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'crichton', git: 'git@github.com:mdsol-share/crichton.git', branch: 'develop'
-gem 'representors', git: 'git@github.com:mdsol-share/representors.git', branch: 'develop'
+gem 'representors', git: 'git@github.com:mdsol-share/representors.git', branch: '0-0-stable'

--- a/lib/moya/Gemfile
+++ b/lib/moya/Gemfile
@@ -27,7 +27,7 @@ gem 'turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 1.2'
 
-gem 'crichton', git: 'git@github.com:mdsol-share/crichton.git', branch: '0-1-stable', require: false #FIXME
+gem 'crichton', git: 'git@github.com:mdsol-share/crichton.git', branch: 'develop', require: false #FIXME
 gem 'representors', git: 'git@github.com:mdsol-share/representors.git', branch: '0-0-stable' #FIXME
 gem 'dice_bag', '~> 0.8'
 gem 'activeuuid', '~> 0.5'

--- a/lib/moya/Gemfile
+++ b/lib/moya/Gemfile
@@ -27,8 +27,8 @@ gem 'turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 1.2'
 
-gem 'crichton', git: 'git@github.com:mdsol/crichton.git', branch: '0-1-stable', require: false #FIXME
-gem 'representors', git: 'git@github.com:mdsol/representors.git', branch: '0-0-stable' #FIXME
+gem 'crichton', git: 'git@github.com:mdsol-share/crichton.git', branch: '0-1-stable', require: false #FIXME
+gem 'representors', git: 'git@github.com:mdsol-share/representors.git', branch: '0-0-stable' #FIXME
 gem 'dice_bag', '~> 0.8'
 gem 'activeuuid', '~> 0.5'
 gem 'pry'

--- a/lib/moya/app/controllers/concerns/drds_decorator.rb
+++ b/lib/moya/app/controllers/concerns/drds_decorator.rb
@@ -1,3 +1,4 @@
+require 'crichton'
 require 'crichton/representor'
 
 class DrdsDecorator

--- a/lib/moya/app/controllers/concerns/drds_decorator.rb
+++ b/lib/moya/app/controllers/concerns/drds_decorator.rb
@@ -4,10 +4,8 @@ class DrdsDecorator
   puts "OVER HERE"
   puts Crichton.inspect
   puts Crichton::Representor.inspect
+  puts require "crichton/representor/factory"
   puts Crichton::Representor::Factory.inspect
-  puts Crichton
-  puts Crichton::Representor
-  puts Crichton::Representor::Factory
   puts "NOT HERE"
   include Crichton::Representor::Factory
 

--- a/lib/moya/app/controllers/concerns/drds_decorator.rb
+++ b/lib/moya/app/controllers/concerns/drds_decorator.rb
@@ -1,12 +1,6 @@
-require 'crichton/representor'
+require 'crichton/representor/factory'
 
 class DrdsDecorator
-  puts "OVER HERE"
-  puts Crichton.inspect
-  puts Crichton::Representor.inspect
-  puts require "crichton/representor/factory"
-  puts Crichton::Representor::Factory.inspect
-  puts "NOT HERE"
   include Crichton::Representor::Factory
 
   attr_reader :collection, :controller

--- a/lib/moya/app/controllers/concerns/drds_decorator.rb
+++ b/lib/moya/app/controllers/concerns/drds_decorator.rb
@@ -4,6 +4,11 @@ class DrdsDecorator
   puts "OVER HERE"
   puts Crichton.inspect
   puts Crichton::Representor.inspect
+  puts Crichton::Representor::Factory.inspect
+  puts Crichton
+  puts Crichton::Representor
+  puts Crichton::Representor::Factory
+  puts "NOT HERE"
   include Crichton::Representor::Factory
 
   attr_reader :collection, :controller

--- a/lib/moya/app/controllers/concerns/drds_decorator.rb
+++ b/lib/moya/app/controllers/concerns/drds_decorator.rb
@@ -1,7 +1,8 @@
-require 'crichton'
 require 'crichton/representor'
 
 class DrdsDecorator
+  puts Crichton.inspect
+  puts Crichton::Representor.inspect
   include Crichton::Representor::Factory
 
   attr_reader :collection, :controller

--- a/lib/moya/app/controllers/concerns/drds_decorator.rb
+++ b/lib/moya/app/controllers/concerns/drds_decorator.rb
@@ -1,6 +1,7 @@
 require 'crichton/representor'
 
 class DrdsDecorator
+  puts "OVER HERE"
   puts Crichton.inspect
   puts Crichton::Representor.inspect
   include Crichton::Representor::Factory


### PR DESCRIPTION
So two things, using the mdsol share version of crichton and representors, and a more explicit require (that was apparently being handled by Crichton.reset before) makes travis happy for the Farscape PR.

```
Finished in 1 minute 4.24 seconds (files took 1.96 seconds to load)
23 examples, 0 failures
Exiting

Randomized with seed 8293
```
